### PR TITLE
Move the version number from setup.py to bitfield/__init__.py

### DIFF
--- a/bitfield/__init__.py
+++ b/bitfield/__init__.py
@@ -8,8 +8,4 @@ from bitfield.models import Bit, BitHandler, CompositeBitField, BitField  # NOQA
 
 default_app_config = 'bitfield.apps.BitFieldAppConfig'
 
-try:
-    VERSION = __import__('pkg_resources') \
-        .get_distribution('bitfield').version
-except Exception:
-    VERSION = 'unknown'
+VERSION = '1.9.3'

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,22 @@
 #!/usr/bin/env python
 
+import ast
+import os.path
 from setuptools import setup, find_packages
+
+class GetVersion(ast.NodeVisitor):
+    def __init__(self, path):
+        with open(path) as f:
+            self.visit(ast.parse(f.read(), path))
+
+    def visit_Assign(self, node):
+        if any(target.id == 'VERSION' for target in node.targets):
+            assert not hasattr(self, 'VERSION')
+            self.VERSION = node.value.s
 
 setup(
     name='django-bitfield',
-    version='1.9.3',
+    version=GetVersion(os.path.join(os.path.dirname(__file__), 'bitfield', '__init__.py')).VERSION,
     author='Disqus',
     author_email='opensource@disqus.com',
     url='https://github.com/disqus/django-bitfield',


### PR DESCRIPTION
This avoids the runtime cost of importing `pkg_resources`, which is typically in the hundreds of milliseconds.  It also fixes a problem where the version number was not being found at all, because the distribution name is `django-bitfield`, not `bitfield`.

Fixes disqus#69.